### PR TITLE
Avoid panic for bio with value `null`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,8 +99,9 @@ async fn get_user_info(login: &str, raw_term: &mut RawTerminal<Stdout>) {
             raw_term,
         );
 
-        custom_print_line(format!(r#""{}""#, user_data.bio,), raw_term);
-        //println!(r#"Bio: '{}'"#, userData.bio);
+        if let Some(bio) = user_data.bio {
+            custom_print_line(format!(r#""{}""#, bio,), raw_term);
+        }
     }
 }
 

--- a/src/resp_structs.rs
+++ b/src/resp_structs.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct UserData {
     pub login: String,
     pub name: String,
-    pub bio: String,
+    pub bio: Option<String>,
     pub public_repos: u32,
     pub followers: u32,
     pub following: u32,


### PR DESCRIPTION
I wanted to check out your tool but after creating my access token, I encountered the following error.
<img width="1607" alt="Screenshot 2024-11-22 at 11 15 14" src="https://github.com/user-attachments/assets/5d9890b1-1c7d-48d1-b26e-25592b628031">

With a little debugging I figured out the error originated from my bio being `null`.
I modified the `UserData` struct to expect a bio string as optional. The bio will now only be printed if it's present.
<img width="1607" alt="Screenshot 2024-11-22 at 11 16 20" src="https://github.com/user-attachments/assets/b757484b-e3c5-4b96-b3b6-35c0b6a9194a">
